### PR TITLE
chore(release): v1.1.3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,15 @@
-MIT License
-
+Sokin Pay for WooCommerce
 Copyright (c) 2025 Plata Capital Ltd.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+You should have received a copy of the GNU General Public License
+along with this program; if not, see <http://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ For detailed documentation:
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE).
+This plugin is licensed under the terms of the [GNU General Public License v2 or later](LICENSE), consistent with the WordPress.org plugin directory requirements.
+
+Sokin is a trading name of Plata Capital Ltd. For information about how Sokin is regulated and the terms under which Sokin services are provided, please refer to the legal and regulatory information on [sokin.com](https://sokin.com) and the region-specific terms and policies listed on the [Sokin Legal](https://sokin.com/legal) page.
 
 While not required by the license, we appreciate contributions back to the project. See our [CONTRIBUTING.md](CONTRIBUTING.md) guidelines for details on how to help improve this plugin.

--- a/includes/class_woo_cpay.php
+++ b/includes/class_woo_cpay.php
@@ -17,7 +17,7 @@ class WooCPay {
 		if (defined('PLUGIN_NAME_VERSION')) {
 			$this->version = PLUGIN_NAME_VERSION;
 		} else {
-			$this->version = '1.1.2';
+			$this->version = '1.1.3';
 		}
 		$this->plugin_name = 'Sokin Pay';
 

--- a/includes/class_woo_cpay_woo_functions.php
+++ b/includes/class_woo_cpay_woo_functions.php
@@ -556,9 +556,6 @@ function woo_cpay_init_gateway_class() {
 			'lastName' => $order->get_billing_last_name(),
 			'email' => $order->get_billing_email(),
 			'billing_address' => $billing_address,
-			'save_card' => true,
-			'payment_method' => [],
-			'isExternal' => true
 		);
 
 		if ($should_include_shipping) {

--- a/includes/class_woo_cpay_woo_functions.php
+++ b/includes/class_woo_cpay_woo_functions.php
@@ -378,7 +378,7 @@ function woo_cpay_init_gateway_class() {
 				'woocommerce_woo_cpay_js',
 				plugins_url('woo_cpay_js.js', __FILE__),
 				array('jquery'),
-				'1.1.2',
+				'1.1.3',
 				true
 			);
 			wp_enqueue_script('woocommerce_woo_cpay_js');

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Sokin Pay ===
 Contributors: Sokin
 Version: 1.1.2
-Tags: sokinpay
+Tags: woocommerce, payments, payment gateway, credit card, ecommerce
 Requires at least: 6.5
 Tested up to: 6.9
 Requires PHP: 7.4
@@ -15,12 +15,20 @@ Easily accept payments on your WordPress site via Sokin Pay payment gateway.
 This plugin seamlessly integrates with your WooCommerce store, providing a secure and efficient way to process payments. Enable a variety of secure payment options, including credit cards and pay by bank.
 Register your business account at [sokin.com](https://sokin.com/business/business-account-signup/).
 
+Sokin is a trading name of Plata Capital Ltd. More information about Sokin’s services and how to sign up can be found on [sokin.com](https://sokin.com).
+
 #### Features
 - Easy installation and setup
 - Secure transactions
 - Support for multiple payment methods
 - Real-time transaction updates
 - Comprehensive customer support
+
+#### Data & privacy
+
+This plugin connects your WooCommerce store to Sokin’s ecommerce payment services. When a customer checks out using Sokin Pay, the plugin sends order and customer information to Sokin for the sole purpose of processing payments and refunds. This includes details such as the customer’s name, email address, billing address (and, when different, shipping address), order total, and currency.
+
+Sokin is a trading name of Plata Capital Ltd. For full details on how Sokin is regulated and how data is handled, please refer to the region-specific Terms & Conditions and related policies available on [sokin.com](https://sokin.com) and the [Sokin Legal](https://sokin.com/legal) page.
 
 #### Configuration
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,11 @@
 === Sokin Pay ===
 Contributors: Sokin
-Version: 1.1.2
+Version: 1.1.3
 Tags: woocommerce, payments, payment gateway, credit card, ecommerce
 Requires at least: 6.5
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 1.1.2
+Stable tag: 1.1.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -67,6 +67,12 @@ Is WooCommerce plugin mandatory for Sokin Pay plugin?
 Yes, Sokin Pay plugin is based on WooCommerce. It uses WooCommerce features and data.
 
 == Changelog ==
+
+= 1.1.3 =
+* Released: 2025-12-04
+* fix: restrict script registration to WooCommerce order screens
+* chore: update license to GNU GPL v2 and enhance documentation
+* refactor: remove unused parameters from order payload
 
 = 1.1.2 =
 * Released: 2025-12-04

--- a/scripts/bump-wp-version.mjs
+++ b/scripts/bump-wp-version.mjs
@@ -60,7 +60,7 @@ async function updatePluginVersion(version) {
   contents = contents.replace(styleVersionRegex, `$1${version}$2`);
 
   const adminScriptVersionRegex =
-    /(wp_register_script\(\s*'sokinpay_gateway_js'[\s\S]*?,\s*array\(\)\s*,\s*')[^']+('\s*,\s*array\(\s*'in_footer'\s*=>\s*true\s*\)\s*\))/;
+    /(wp_register_script\(\s*'sokinpay_gateway_js'[\s\S]*?,\s*array\([^)]*\)\s*,\s*')[^']+(')/;
   if (!adminScriptVersionRegex.test(contents)) {
     throw new Error('Unable to locate sokinpay_gateway_js version in sokinpay.php');
   }

--- a/sokinpay.php
+++ b/sokinpay.php
@@ -4,7 +4,7 @@
  * Plugin Name: Sokin Pay
  * Plugin URI:
  * Description: This plugin seamlessly integrates with your WooCommerce store, providing a secure and efficient way to process payments. Enable a variety of secure payment options, including credit cards and pay by bank.
- * Version: 1.1.2
+ * Version: 1.1.3
  * Author: Sokin
  * Author URI:
  * Requires at least: 6.5
@@ -26,7 +26,7 @@ if (!defined('WPINC')) {
 /**
  * Define plugin's Version constant
  */
-define('WOO_CUSTOM_PAYMENT', '1.1.2');
+define('WOO_CUSTOM_PAYMENT', '1.1.3');
 
 /**
  * The code that runs during plugin activation
@@ -40,7 +40,7 @@ function activate_woo_cpay() {
  * Register the stylesheet
  */
 function register_sokinpay_gateway_styles() {
-	wp_register_style('sokinpay_gateway_style', plugin_dir_url(__FILE__) . 'assets/css/style.css', array(), '1.1.2', 'all');
+	wp_register_style('sokinpay_gateway_style', plugin_dir_url(__FILE__) . 'assets/css/style.css', array(), '1.1.3', 'all');
 	wp_enqueue_style('sokinpay_gateway_style');
 }
 
@@ -67,7 +67,7 @@ function register_sokinpay_gateway_scripts($hook) {
 		'sokinpay_gateway_js',
 		plugin_dir_url(__FILE__) . 'includes/js/woo_cpay_js.js',
 		array('jquery'),
-		'1.1.2',
+		'1.1.3',
 		true
 	);
 	wp_enqueue_script('sokinpay_gateway_js');

--- a/sokinpay.php
+++ b/sokinpay.php
@@ -10,7 +10,6 @@
  * Requires at least: 6.5
  * Tested up to: 6.9
  * Requires PHP: 7.4
- * Stable tag: sokinpay
  * License: GPLv2 or later
  * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: sokin-pay
@@ -49,10 +48,28 @@ function register_sokinpay_gateway_styles() {
 add_action('wp_enqueue_scripts', 'register_sokinpay_gateway_styles');
 
 /**
- * Register custom javascript file for Admin panel pages use only
+ * Register custom javascript file for Admin order screens.
  */
 function register_sokinpay_gateway_scripts($hook) {
-	wp_register_script('sokinpay_gateway_js', plugin_dir_url(__FILE__) . 'includes/js/woo_cpay_js.js', array(), '1.1.2', array('in_footer' => true));
+	// Only load on post edit screens for WooCommerce orders.
+	if ('post.php' !== $hook && 'post-new.php' !== $hook) {
+		return;
+	}
+
+	if (function_exists('get_current_screen')) {
+		$screen = get_current_screen();
+		if (!$screen || 'shop_order' !== $screen->post_type) {
+			return;
+		}
+	}
+
+	wp_register_script(
+		'sokinpay_gateway_js',
+		plugin_dir_url(__FILE__) . 'includes/js/woo_cpay_js.js',
+		array('jquery'),
+		'1.1.2',
+		true
+	);
 	wp_enqueue_script('sokinpay_gateway_js');
 }
 


### PR DESCRIPTION
This release (1.1.3) focuses on plugin metadata cleanup, license compliance, and admin script loading optimization. The changes prepare the plugin for WordPress.org directory requirements by switching from MIT to GPLv2 license and adding required regulatory disclosures.

### Key Changes:

- License migration from MIT to GPLv2+ for WordPress.org compliance
- Added data privacy and regulatory information disclosures
- Optimized admin JavaScript loading to WooCommerce order screens only
