### PR TITLE
fix(dev): guard release-tree normalization to protect host checkouts

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -14,6 +14,10 @@ services:
       SOKIN_REDIRECT_URL: ${SOKIN_REDIRECT_URL}
       SOKIN_X_API_KEY: ${SOKIN_X_API_KEY}
       SOKIN_API_URL: ${SOKIN_API_URL}
+      # The deploy image bakes plugin files in; trimming dev-only files in the
+      # image is safe and matches the release ZIP layout. Local docker-compose
+      # bind-mounts the host repo and must NOT enable this.
+      SOKIN_NORMALIZE_PLUGIN_TREE: "1"
     depends_on:
       - db
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,13 @@ services:
       SOKIN_X_API_KEY: ${SOKIN_X_API_KEY:-dummy_api_key}
       SOKIN_API_URL: ${SOKIN_API_URL:-https://api.sandbox.sokin.net/api/services/v1}
 
+      # Local dev bind-mounts the host checkout into the container at
+      # wp-content/plugins/sokin-pay. The release-tree normalization step in
+      # tests/docker-entrypoint.sh would otherwise rm -rf dev files (.git,
+      # docker-compose.yml, package.json, etc.) directly from the host repo.
+      # Keep this disabled here; the deploy image enables it explicitly.
+      SOKIN_NORMALIZE_PLUGIN_TREE: "0"
+
       # WordPress URL Configuration
       WORDPRESS_CONFIG_EXTRA: |
         define('WP_HOME',    '${VIRTUAL_HOST:-https://localhost:8443}');

--- a/tests/docker-entrypoint.sh
+++ b/tests/docker-entrypoint.sh
@@ -66,26 +66,40 @@ if ! wp plugin is-active sokin-pay; then
 fi
 
 # --- 6. Normalize plugin tree to match release ZIP ---
-PLUGIN_DIR="/var/www/html/wp-content/plugins/sokin-pay"
+# This step is destructive: it deletes development-only files from the plugin
+# directory so the running site mirrors what ships in the release archive.
+# When the host repository is bind-mounted into the container (as in the
+# default local docker-compose.yml), running this on the mount would delete
+# files from the developer's checkout (including .git, docker-compose.yml,
+# package.json, etc.). The default is therefore to SKIP this step; opt in
+# explicitly via SOKIN_NORMALIZE_PLUGIN_TREE=1 in environments that ship a
+# self-contained image (e.g. the deploy/release pipeline) and where the
+# plugin directory is NOT a host bind mount.
+if [ "${SOKIN_NORMALIZE_PLUGIN_TREE:-0}" = "1" ]; then
+    PLUGIN_DIR="/var/www/html/wp-content/plugins/sokin-pay"
+    echo "Normalizing plugin tree to match release ZIP at $PLUGIN_DIR..."
 
-# Remove development-only directories and files that are excluded from the release archive
-rm -rf \
-  "$PLUGIN_DIR/local-dev" \
-  "$PLUGIN_DIR/tests" \
-  "$PLUGIN_DIR/wp-content" \
-  "$PLUGIN_DIR/scripts" \
-  "$PLUGIN_DIR/.github"
+    # Remove development-only directories and files that are excluded from the release archive
+    rm -rf \
+      "$PLUGIN_DIR/local-dev" \
+      "$PLUGIN_DIR/tests" \
+      "$PLUGIN_DIR/wp-content" \
+      "$PLUGIN_DIR/scripts" \
+      "$PLUGIN_DIR/.github"
 
-rm -f \
-  "$PLUGIN_DIR"/docker-compose* \
-  "$PLUGIN_DIR"/*.log \
-  "$PLUGIN_DIR"/package.json \
-  "$PLUGIN_DIR"/package-lock.json \
-  "$PLUGIN_DIR"/.releaserc.json \
-  "$PLUGIN_DIR"/.distignore
+    rm -f \
+      "$PLUGIN_DIR"/docker-compose* \
+      "$PLUGIN_DIR"/*.log \
+      "$PLUGIN_DIR"/package.json \
+      "$PLUGIN_DIR"/package-lock.json \
+      "$PLUGIN_DIR"/.releaserc.json \
+      "$PLUGIN_DIR"/.distignore
 
-# Clean common hidden cruft (matches README packaging excludes for .git* and .DS_Store)
-find "$PLUGIN_DIR" \( -name '.git*' -o -name '.DS_Store' \) -prune -exec rm -rf {} + 2>/dev/null || true
+    # Clean common hidden cruft (matches README packaging excludes for .git* and .DS_Store)
+    find "$PLUGIN_DIR" \( -name '.git*' -o -name '.DS_Store' \) -prune -exec rm -rf {} + 2>/dev/null || true
+else
+    echo "Skipping release-tree normalization (SOKIN_NORMALIZE_PLUGIN_TREE!=1); preserving plugin directory as-is."
+fi
 
 # Install & activate Plugin Check (PCP) for local/plugin CI analysis
 if ! wp plugin is-installed plugin-check; then


### PR DESCRIPTION
## Description

The container entrypoint at `tests/docker-entrypoint.sh` includes a
"normalize plugin tree to match release ZIP" step that runs `rm -rf`
against the plugin directory. Because the local `docker-compose.yml`
bind-mounts the host repository into the container at
`wp-content/plugins/sokin-pay`, that step would silently delete files
directly from the developer's checkout — including `.git/`,
`docker-compose.yml`, `package.json`, `local-dev/`, `tests/`,
`scripts/`, `.github/`, `.releaserc.json`, and `.distignore` — leaving
a non-git, non-buildable working directory after a routine
`docker-compose up`.

This change makes the destructive normalization opt-in via a new
`SOKIN_NORMALIZE_PLUGIN_TREE` env var (default `0`). The deploy compose
file sets it to `1` because the deploy image ships plugin files baked
into the image and is not a host bind mount, so trimming there is safe
areserves the previous release-ZIP layout.

## Related Issues

N/A

## Changes Made

- Wrap step 6 of `tests/docker-entrypoint.sh` in an
  `if [ \"\${SOKIN_NORMALIZE_PLUGIN_TREE:-0}\" = \"1\" ]; then ... fi`
  guard, with an explanatory comment block and a clear log line in
  both branches.
- `docker-compose.yml`: explicitly set `SOKIN_NORMALIZE_PLUGIN_TREE: \"0\"`
  with a comment explaining why local dev must not enable it.
- `docker-compose.deploy.yml`: set `SOKIN_NORMALIZE_PLUGIN_TREE: \"1\"`
  to preserve the prior release-image behavior.

## Screenshots

N/A — backend / dev-tooling change only.

## Testing Instructions

1. Fresh clone the repo and `docker-compose up --build -d` from the
   project root.
2. Confirm the host checkout is not mutated:
   `git status` shows no unexpected deletions; `.git/`,
   `docker-compose.yml`, `package.json`, `local-dev/`, `tests/`,
   `scripts/`, `.github/`, `.releaserc.json`, `.distignore` all
   present.
3. Confirm the entrypoint logs:
   `Skipping release-tree noalization (SOKIN_NORMALIZE_PLUGIN_TREE!=1); preserving plugin directory as-is.`
4. Confirm the site is functional:
   - `curl -kI https://localhost:8443` → 200
   - `wp plugin list` inside the container shows `sokin-pay` and
     `woocommerce` active.
5. Validate the opt-in branch in isolation by running the same
   normalization block (or building the deploy image) with
   \`SOKIN_NORMALIZE_PLUGIN_TREE=1\`; confirm dev-only files are
   removed and only release-ZIP contents remain.

## Additional Notes

- No application-code or gateway behavior changes.
- The only runtime difference for local dev is that the plugin tree
  inside the container now retains dev-only files (matching what is
  on disk via the bind mount), which is the existing reality on
  every developer machine that mounts the repo.
- Release/deploy image behavior is unchanged because the deploy
  compose file opts in.

## Checklist

- [x] Change is small, clear, and follows style guidelines
- [ ] Tests added/updated and all tests pass locay _(no test suite covers the entrypoint shell logic; manual verification covered both branches)_
- [ ] Docs updated if behavior or API changed _(README local-dev section unchanged; behavior matches what users already expected)_
- [x] Self-review done: names clear, dead code removed, edge cases considered
- [x] No new lints/warnings locally or in CI

## PCI DSS Significance Assessment & Review

* [x] PCI DSS §6.4.6 Significance Assessment performed, and all required follow-up actions completed.

Not significant: no network changes, no new systems/technologies, no
changes to card-data flows or storage. Local dev tooling only.