### PR TITLE
fix(dev): keep Plugin Check active in provisioned sites

### DIFF
--- a/tests/docker-entrypoint.sh
+++ b/tests/docker-entrypoint.sh
@@ -66,6 +66,8 @@ if ! wp plugin is-active sokin-pay; then
 fi
 
 # --- 6. Normalize plugin tree to match release ZIP ---
+PLUGIN_DIR="/var/www/html/wp-content/plugins/sokin-pay"
+
 # This step is destructive: it deletes development-only files from the plugin
 # directory so the running site mirrors what ships in the release archive.
 # When the host repository is bind-mounted into the container (as in the
@@ -76,7 +78,6 @@ fi
 # self-contained image (e.g. the deploy/release pipeline) and where the
 # plugin directory is NOT a host bind mount.
 if [ "${SOKIN_NORMALIZE_PLUGIN_TREE:-0}" = "1" ]; then
-    PLUGIN_DIR="/var/www/html/wp-content/plugins/sokin-pay"
     echo "Normalizing plugin tree to match release ZIP at $PLUGIN_DIR..."
 
     # Remove development-only directories and files that are excluded from the release archive
@@ -100,6 +101,20 @@ if [ "${SOKIN_NORMALIZE_PLUGIN_TREE:-0}" = "1" ]; then
 else
     echo "Skipping release-tree normalization (SOKIN_NORMALIZE_PLUGIN_TREE!=1); preserving plugin directory as-is."
 fi
+
+# Remove legacy files from pre-sokin-pay builds so Plugin Check scans only the
+# current plugin tree in reused dev/test environments.
+LEGACY_PLUGIN_FILES=(
+    "$PLUGIN_DIR/includes/class_woo_cpay_loader.php"
+    "$PLUGIN_DIR/includes/class_woo_cpay_woo_functions.php"
+)
+
+for legacy_plugin_file in "${LEGACY_PLUGIN_FILES[@]}"; do
+    if [ -f "$legacy_plugin_file" ]; then
+        echo "Removing legacy plugin file: $legacy_plugin_file"
+        rm -f -- "$legacy_plugin_file"
+    fi
+done
 
 # Install & activate Plugin Check (PCP) for local/plugin CI analysis
 PLUGIN_CHECK_SLUG="plugin-check"

--- a/tests/docker-entrypoint.sh
+++ b/tests/docker-entrypoint.sh
@@ -102,8 +102,13 @@ else
 fi
 
 # Install & activate Plugin Check (PCP) for local/plugin CI analysis
-if ! wp plugin is-installed plugin-check; then
-    wp plugin install plugin-check --activate
+PLUGIN_CHECK_SLUG="plugin-check"
+if ! wp plugin is-installed "$PLUGIN_CHECK_SLUG"; then
+    wp plugin install "$PLUGIN_CHECK_SLUG"
+fi
+
+if ! wp plugin is-active "$PLUGIN_CHECK_SLUG"; then
+    wp plugin activate "$PLUGIN_CHECK_SLUG"
 fi
 
 # --- 7. Configure Options ---

--- a/tests/verify-entrypoint-cleanup.sh
+++ b/tests/verify-entrypoint-cleanup.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+entrypoint_path="${1:-tests/docker-entrypoint.sh}"
+
+legacy_plugin_files=(
+  "includes/class_woo_cpay_loader.php"
+  "includes/class_woo_cpay_woo_functions.php"
+)
+
+for legacy_plugin_file in "${legacy_plugin_files[@]}"; do
+  if ! grep -Fq "$legacy_plugin_file" "$entrypoint_path"; then
+    echo "Missing cleanup for legacy plugin file: $legacy_plugin_file" >&2
+    exit 1
+  fi
+done
+
+cleanup_line="$(
+  awk '/LEGACY_PLUGIN_FILES=/ { print NR; exit }' "$entrypoint_path"
+)"
+plugin_check_line="$(
+  awk '/PLUGIN_CHECK_SLUG=/ { print NR; exit }' "$entrypoint_path"
+)"
+
+if [ -z "$cleanup_line" ] || [ -z "$plugin_check_line" ]; then
+  echo "Could not find cleanup and Plugin Check provisioning blocks." >&2
+  exit 1
+fi
+
+if [ "$cleanup_line" -ge "$plugin_check_line" ]; then
+  echo "Legacy file cleanup must run before Plugin Check provisioning." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Keeps Plugin Check (PCP) provisioning idempotent for dev/test WordPress environments.
- Installs PCP when missing and explicitly activates it when an existing volume has it inactive.
- Prunes stale legacy `woo_cpay` PHP files before PCP runs so reused dev/test plugin trees scan only current source files.
- Replaces generic WooCommerce credit card form hook invocations with Sokin-prefixed checkout field hooks.

## Test plan
- [x] `bash -n tests/docker-entrypoint.sh`
- [x] `bash -n tests/verify-entrypoint-cleanup.sh`
- [x] `bash tests/verify-entrypoint-cleanup.sh`
- [x] `bash -n tests/verify-prefixed-hooks.sh`
- [x] `bash tests/verify-prefixed-hooks.sh`
- [x] `php -l includes/class-platasokin-wc-gateway.php`
- [x] `docker compose -f docker-compose.deploy.yml config --quiet` with deployment env placeholders
- [x] `docker compose -f docker-compose.yml config --quiet`

## PCI DSS Significance Assessment & Review

* [x] PCI DSS §6.4.6 Significance Assessment performed, and all required follow-up actions completed.

Not significant: dev/test provisioning and static compliance changes; no network changes, new systems/technologies, card data flow changes, or card data storage changes.