### PR TITLE
fix(dev): prefix checkout field hooks for PCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,18 @@ A root `docker-compose.yml` spins up WordPress, MariaDB, and Nginx. TLS uses `lo
 1. Go to WooCommerce > Settings > Payments
 2. Enable and configure Sokin Pay
 3. Enter your API credentials from your [Sokin Business Account](https://sokin.com/business/business-account-signup/)
+
+## Developer Hooks
+
+Sokin Pay exposes checkout field extension points through plugin-prefixed hooks:
+
+- `platasokin_credit_card_form_start`
+- `platasokin_credit_card_form_end`
+
+If your integration previously used `woocommerce_credit_card_form_start` or
+`woocommerce_credit_card_form_end` for Sokin Pay checkout customizations, update it
+to the `platasokin_*` hook names above.
+
 ## Testing
 
 There is no PHPUnit suite checked into this repository yet; validation is manual.

--- a/includes/class-platasokin-wc-gateway.php
+++ b/includes/class-platasokin-wc-gateway.php
@@ -365,9 +365,9 @@ function platasokin_init_gateway_class() {
 		public function payment_fields() {
 			echo '<p style="margin:0">' . esc_attr( $this->description ) . '</p>';
 
-			do_action( 'woocommerce_credit_card_form_start', $this->id );
+			do_action( 'platasokin_credit_card_form_start', $this->id );
 
-			do_action( 'woocommerce_credit_card_form_end', $this->id );
+			do_action( 'platasokin_credit_card_form_end', $this->id );
 
 			echo '<div class="clear"></div></fieldset>';
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -50,6 +50,15 @@ Sokin is a trading name of Plata Capital Ltd. For full details on how Sokin is r
    - View transaction details under WooCommerce > Orders.
    - Process refunds and handle disputes directly from your WooCommerce dashboard.
 
+#### Developer hooks
+
+Sokin Pay exposes checkout field extension points through plugin-prefixed hooks:
+
+* `platasokin_credit_card_form_start`
+* `platasokin_credit_card_form_end`
+
+If your integration previously used `woocommerce_credit_card_form_start` or `woocommerce_credit_card_form_end` for Sokin Pay checkout customizations, update it to the `platasokin_*` hook names above.
+
 #### Support
 For any issues or questions, please contact our support team at [support@sokin.com](mailto:support@sokin.com).
 

--- a/tests/verify-prefixed-hooks.sh
+++ b/tests/verify-prefixed-hooks.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+gateway_path="${1:-includes/class-platasokin-wc-gateway.php}"
+
+legacy_hooks=(
+  "woocommerce_credit_card_form_start"
+  "woocommerce_credit_card_form_end"
+)
+
+prefixed_hooks=(
+  "platasokin_credit_card_form_start"
+  "platasokin_credit_card_form_end"
+)
+
+for legacy_hook in "${legacy_hooks[@]}"; do
+  if grep -Fq "do_action( '$legacy_hook'" "$gateway_path"; then
+    echo "Found non-prefixed hook invocation: $legacy_hook" >&2
+    exit 1
+  fi
+done
+
+for prefixed_hook in "${prefixed_hooks[@]}"; do
+  if ! grep -Fq "do_action( '$prefixed_hook'" "$gateway_path"; then
+    echo "Missing prefixed hook invocation: $prefixed_hook" >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
## Summary
- Replaces generic WooCommerce credit card form hook invocations with Sokin-prefixed checkout field hooks.
- Adds a focused static check so PCP does not regress on non-prefixed hook invocations.

## Test plan
- [x] `bash -n tests/verify-prefixed-hooks.sh`
- [x] `bash tests/verify-prefixed-hooks.sh`
- [x] `php -l includes/class-platasokin-wc-gateway.php`
- [x] `bash -n tests/docker-entrypoint.sh`
- [x] `bash -n tests/verify-entrypoint-cleanup.sh`
- [x] `bash tests/verify-entrypoint-cleanup.sh`
- [x] `docker compose -f docker-compose.deploy.yml config --quiet` with deployment env placeholders
- [x] `docker compose -f docker-compose.yml config --quiet`