### PR TITLE
ci(wporg): tighten .distignore so published zip ships runtime only

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,18 +1,35 @@
+# Files and directories excluded from the WordPress.org distribution.
+# Consumed by both rsync (deploy-wporg.yml build step) and the 10up
+# action-wordpress-plugin-deploy step. Anything not in this list ends up
+# in the published zip and on plugins.svn.wordpress.org.
+
 # Version control
 .git
 .github/
 .gitignore
 .gitattributes
 
-# Local OS files
+# Local OS / editor metadata
 .DS_Store
+.editorconfig
+.vscode/
+.idea/
 
 # Tooling and automation
+.distignore
+.releaserc.json
 package.json
 package-lock.json
-.releaserc.json
+pnpm-lock.yaml
 scripts/
 autom.plan.md
+
+# Repository documentation that is not the WordPress.org readme
+CONTRIBUTING.md
+README.md
+
+# Build output (prevents rsync self-copy when dist/ is the destination)
+dist/
 
 # Development assets
 node_modules/
@@ -22,4 +39,3 @@ wp-content/
 docker-compose*
 *.log
 **/docker-entrypoint.sh
-


### PR DESCRIPTION
## Summary

Excludes dev-only metadata, the GitHub-only \`README.md\`, lockfiles, and the build directory from the WordPress.org distribution. The previous deny-list let \`pnpm-lock.yaml\`, \`CONTRIBUTING.md\`, the repo \`README.md\`, \`.distignore\` itself, and an empty self-copy of \`dist/\` leak into the published zip — exactly the kind of files Plugin Check and WP.org review flag.

This aligns the workflow's automated zip with the clean zip used for the initial WP.org review submission, so subsequent automated deploys don't regress.

### What lands in the zip after this change

\`\`\`
LICENSE
assets/  (css/, images/)
includes/  (PHP and JS runtime)
index.php
languages/woo-cpay.pot
readme.txt
sokin-pay.php
uninstall.php
\`\`\`

No behavioral changes for installed plugins; only the published zip's contents change.

## Test plan

- [x] Local rsync simulation produces the file list above with no dev metadata.
- [ ] After merge, run \`Deploy to WordPress.org\` manually with \`tag: v1.1.5\` (or next future tag) and verify the attached zip matches the simulation output.