### PR TITLE
ci: refresh workflow actions ahead of Node 20 sunset

### DIFF
--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -15,10 +15,10 @@ jobs:
       name: pr-deploy
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v5
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -26,10 +26,10 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@19d944daaa35f0fa1d3f7f8af1d3f2e5de25c5b7 # v2.1.4
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: true
@@ -41,11 +41,11 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Read docker-compose.deploy.yml
         id: compose_file
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
@@ -54,7 +54,7 @@ jobs:
           result-encoding: string
 
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@v0.1.7
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.SSH_USER }}
@@ -83,7 +83,7 @@ jobs:
             EOF
             docker-compose down || true && docker-compose pull && docker-compose up -d --force-recreate
       - name: Post PR Comment with Deployment URL
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           message: |
             The PR environment has been deployed and is available at:

--- a/.github/workflows/deploy-release.yaml
+++ b/.github/workflows/deploy-release.yaml
@@ -47,12 +47,12 @@ jobs:
       name: release-demo
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -60,10 +60,10 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@19d944daaa35f0fa1d3f7f8af1d3f2e5de25c5b7 # v2.1.4
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           push: true
@@ -80,13 +80,13 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
 
       - name: Read docker-compose.deploy.yml
         id: compose_file
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
@@ -95,7 +95,7 @@ jobs:
           result-encoding: string
 
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@v0.1.7
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.SSH_USER }}

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -76,7 +76,7 @@ jobs:
           node scripts/bump-wp-version.mjs "$VERSION" "$B64"
 
       - name: Create release PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: release/v${{ steps.next.outputs.version }}

--- a/.github/workflows/teardown-pr.yaml
+++ b/.github/workflows/teardown-pr.yaml
@@ -15,7 +15,7 @@ jobs:
       name: pr-deploy
     steps:
       - name: Teardown via SSH
-        uses: appleboy/ssh-action@v0.1.7
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.SSH_USER }}


### PR DESCRIPTION
## Summary

GitHub forces all Node-20 actions to Node 24 from **2 June 2026** and removes the Node-20 runtime on **16 September 2026**. Refreshes every action across the workflow set to a version that already runs on Node 20+/24, picks up the v2 ECR-login default that masks the docker password, and aligns with repo convention by SHA-pinning third-party actions.

### Workflows touched
- \`deploy-release.yaml\` — release demo deploy
- \`deploy-pr.yaml\` — per-PR ephemeral environment
- \`teardown-pr.yaml\` — per-PR teardown
- \`prepare-release-pr.yml\` — release PR preparer (currently blocked by SRE policy but kept current)

\`release.yml\` and \`deploy-wporg.yml\` already use up-to-date majors and are not touched.

### Action versions
| Action | From | To |
|---|---|---|
| \`actions/checkout\` | \`@v3\` | \`@v4\` |
| \`actions/github-script\` | \`@v6\` | \`@v7\` |
| \`aws-actions/configure-aws-credentials\` | \`@v2\` / \`@v5\` | \`@v6.1.0\` (SHA-pinned) |
| \`aws-actions/amazon-ecr-login\` | \`@v1\` | \`@v2.1.4\` (SHA-pinned) |
| \`docker/build-push-action\` | \`@v4\` | \`@v7.1.0\` (SHA-pinned) |
| \`appleboy/ssh-action\` | \`@v0.1.7\` | \`@v1.2.5\` (SHA-pinned) |
| \`marocchino/sticky-pull-request-comment\` | \`@v2\` | \`@v3.0.4\` (SHA-pinned) |
| \`peter-evans/create-pull-request\` | \`@v6\` | \`@v8.1.1\` (SHA-pinned) |

The inputs we pass to each action (\`aws-access-key-id\`/\`aws-secret-access-key\`/\`aws-region\`; \`context\`/\`push\`/\`file\`/\`tags\`/\`build-args\`; \`host\`/\`username\`/\`key\`/\`script\`; \`message\`; \`token\`/\`branch\`/\`base\`/\`commit-message\`/\`title\`/\`body\`/\`labels\`) are stable across the version jumps, so behavior is preserved.

Third-party actions pinned by commit SHA per repo convention (matches the recently-pinned \`10up/action-wordpress-plugin-deploy\`). GitHub-owned actions stay on major-version tags.

No behavioral changes for any deploy.

## Test plan

- [ ] After merge, run \`Deploy Release Demo\` manually with \`tag: v1.1.4\`; expect green steps and no Node-20 / mask-password warnings.
- [ ] On the next opened PR, observe \`Deploy PR Environment\` succeed end-to-end (build, push, SSH deploy, sticky comment with the URL).
- [ ] On that same PR's close, observe \`Teardown PR Environment\` SSH step succeed.
- [ ] (When the SRE block on \`prepare-release-pr.yml\` is lifted) Manual dispatch of that workflow opens the release PR as before.