### PR TITLE
ci: bump GitHub-owned actions to Node-24 majors

### DIFF
--- a/.github/workflows/deploy-pr.yaml
+++ b/.github/workflows/deploy-pr.yaml
@@ -15,7 +15,7 @@ jobs:
       name: pr-deploy
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
@@ -41,11 +41,11 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Read docker-compose.deploy.yml
         id: compose_file
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/deploy-release.yaml
+++ b/.github/workflows/deploy-release.yaml
@@ -47,7 +47,7 @@ jobs:
       name: release-demo
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
 
@@ -80,13 +80,13 @@ jobs:
     needs: [build]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
 
       - name: Read docker-compose.deploy.yml
         id: compose_file
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/deploy-wporg.yml
+++ b/.github/workflows/deploy-wporg.yml
@@ -48,13 +48,13 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ steps.release.outputs.tag }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.14.0'
           check-latest: true

--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -25,12 +25,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.14.0'
           check-latest: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,12 +27,12 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.14.0'
           check-latest: true


### PR DESCRIPTION
## Summary

Follow-up to #39. The previous refresh landed on action majors (\`checkout@v4\`, \`setup-node@v4\`, \`github-script@v7\`) that still ship a Node-20 runtime, so the deprecation warning kept firing on the post-merge demo deploy. Move to the current majors that run on Node 24 to silence the warning ahead of the September 2026 runtime removal.

| Action | From | To |
|---|---|---|
| \`actions/checkout\` | \`@v4\` | \`@v6\` |
| \`actions/setup-node\` | \`@v4\` | \`@v6\` |
| \`actions/github-script\` | \`@v7\` | \`@v9\` |

The inputs we pass (\`ref\`, \`fetch-depth\`, \`node-version\`, \`check-latest\`, \`script\`, \`result-encoding\`) are unchanged in these majors, so behavior is preserved.

Touches every workflow file: \`deploy-pr.yaml\`, \`deploy-release.yaml\`, \`deploy-wporg.yml\`, \`prepare-release-pr.yml\`, \`release.yml\`.

## Test plan

- [ ] After merge, manual \`Deploy Release Demo\` with \`tag: v1.1.4\` — expect green steps and **no** Node-20 deprecation annotations.
- [ ] On the next PR, \`Deploy PR Environment\` succeeds end-to-end.
- [ ] On a future release merge, \`Release\` workflow runs cleanly with \`actions/setup-node@v6\`.