### PR TITLE
ci(release): merchant-facing notes from readme.txt + script-driven runbook

### DIFF
--- a/.github/workflows/prepare-release-pr.yml
+++ b/.github/workflows/prepare-release-pr.yml
@@ -75,22 +75,47 @@ jobs:
           B64=$(printf '%s' "${NOTES:-Maintenance updates.}" | base64 | tr -d '\n')
           node scripts/bump-wp-version.mjs "$VERSION" "$B64"
 
-      - name: Create release PR
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          branch: release/v${{ steps.next.outputs.version }}
-          base: main
-          commit-message: |
-            chore(release): v${{ steps.next.outputs.version }}
-          title: |
-            release: v${{ steps.next.outputs.version }}
-          body: |
-            Prepares the release bump to v${{ steps.next.outputs.version }}.
+      - name: Commit, push, and open release PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.next.outputs.version }}
+          CURRENT: ${{ steps.cur.outputs.current }}
+        shell: bash
+        run: |
+          set -euo pipefail
 
-            - Updates `sokin-pay.php` and `readme.txt`
-            - Changelog is kept newest-first
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-            After merging this PR, the Release workflow will tag and publish.
-          labels: release
+          BRANCH="release/v$VERSION"
+          git checkout -b "$BRANCH"
+
+          # Bullet-list of commit subjects since the last tag becomes the
+          # commit body. GitHub's squash UI defaults the squash body to the
+          # PR's single commit body, so this also seeds a useful squash body.
+          COMMITS=""
+          if [ -n "${CURRENT:-}" ] && git rev-parse -q --verify "v$CURRENT" >/dev/null; then
+            COMMITS="$(git log "v$CURRENT..HEAD" --no-merges --pretty='* %s')"
+          fi
+
+          git add sokin-pay.php readme.txt
+          if [ -n "$COMMITS" ]; then
+            git commit -m "chore(release): v$VERSION" -m "$COMMITS"
+          else
+            git commit -m "chore(release): v$VERSION"
+          fi
+
+          git push --force-with-lease -u origin "$BRANCH"
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "release: v$VERSION" \
+            --label release \
+            --body "Prepares the release bump to v$VERSION.
+
+          - Updates \`sokin-pay.php\` and \`readme.txt\`
+          - Changelog is kept newest-first
+
+          After merging this PR, the Release workflow will tag and publish."
 

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -20,8 +20,12 @@
         ]
       }
     ],
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/exec",
+      {
+        "generateNotesCmd": "node scripts/extract-readme-notes.mjs ${nextRelease.version}"
+      }
+    ],
     "@semantic-release/github"
   ]
 }
-

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -79,4 +79,4 @@ Submit the zip at https://wordpress.org/plugins/developers/add/. Once approved, 
 
 When the org issues a GitHub App token (or PAT) for releases, set it as `GITHUB_TOKEN` for the `npx semantic-release` step in `release.yml`. Releases created by an App or PAT do fire downstream `release` events, which makes the `publish` step automatic. The script stays as a recovery path.
 
-A second improvement is unblocking `prepare-release-pr.yml` (currently blocked by SRE) so the release PR can be opened from the Actions UI instead of locally. The script and the workflow can coexist.
+`prepare-release-pr.yml` is also kept up to date with the script: when SRE allows the bot to open PRs, dispatching the workflow will produce the same release PR (same `chore(release): v…` subject, same bullet-list commit body) the script produces locally. Until then, the script is the canonical entry point.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,96 +1,37 @@
 # Releasing Sokin Pay
 
-This guide describes how to cut a new release of the plugin, publish it to WordPress.org, and redeploy the demo. The process is currently manual end-to-end because the GitHub-Actions automation that opens the release PR is blocked by SRE policy and `semantic-release`'s downstream-trigger limitation. The runbook below is what the automation would have done.
+The release flow is currently manual end-to-end because the GitHub-Actions automation that opens the release PR is blocked by SRE policy and `semantic-release`'s downstream-trigger limitation. `scripts/release.sh` walks you through it.
 
-## Overview
+```bash
+scripts/release.sh prepare   # opens the release PR
+# (review, squash-merge, the Release workflow tags and publishes)
+scripts/release.sh publish v1.2.3   # fires the post-merge deploys
+```
 
-| Stage | Trigger | Workflow |
-|---|---|---|
-| 1. Open release PR | Manual (this guide) | _would be_ `prepare-release-pr.yml` |
-| 2. Tag and create GitHub Release | Squash-merge of release PR with `chore(release): v…` subject | `release.yml` (runs `semantic-release`) |
-| 3. Publish to WordPress.org | GitHub Release published, **or** manual button | `deploy-wporg.yml` |
-| 4. Redeploy demo site | GitHub Release published, **or** manual button | `deploy-release.yaml` |
-
-**Important.** Releases created by `semantic-release` use the default `GITHUB_TOKEN`. GitHub deliberately suppresses downstream workflow runs for events created by that token, so stages 3 and 4 do **not** auto-fire from stage 2. Use the manual buttons until the org issues a GitHub App token (or PAT) for the release workflow.
+If anything fails, see the **[Failure modes](#failure-modes)** section.
 
 ## Prerequisites
 
 - Push access to `main` and the ability to merge release PRs.
 - `gh` CLI authenticated against `platacapital/sokin-woocommerce-plugin`.
-- Node.js 22.14.0 (matches the workflow). Only needed for running the bump script.
+- Node.js 22.14.0 (matches the workflow). Used by the bump script.
+- A clean working tree on a checkout that can fast-forward `main`.
 
-## 1. Cut the release PR
+## What the script does
 
-Pick the next version using [Conventional Commits](https://www.conventionalcommits.org/) rules from `.releaserc.json`:
+### `prepare`
 
-- `fix:` / `perf:` → patch
-- `feat:` → minor
-- Any commit with `BREAKING CHANGE:` footer or `!` in the type → major
-- `chore:`, `docs:`, `ci:`, `build:`, `refactor:`, `test:`, `style:` → no release on their own
+1. Verifies the working tree is clean and syncs `main` to the remote.
+2. Shows commits since the last tag and prompts for the bump type (patch/minor/major).
+3. Opens `$EDITOR` for the merchant-facing release notes. Write for store operators, not engineers; mention any developer-visible changes (renamed hooks, new settings) explicitly. Otherwise a generic maintenance line is fine.
+4. Cuts a `release/v$VERSION` branch and runs `scripts/bump-wp-version.mjs`, which updates the plugin header `Version`, the `PLATASOKIN_VERSION` constant, and prepends a new `= $VERSION =` block to the `readme.txt` changelog.
+5. Shows the diff, asks for confirmation, then commits with the gating subject `chore(release): v$VERSION`, pushes, and opens the PR.
 
-Sanity-check the commits since the last tag:
+The merchant-facing notes you wrote in step 3 become both the WordPress.org changelog entry and (after the Release workflow runs) the GitHub Release body, via `scripts/extract-readme-notes.mjs` wired into `.releaserc.json`. No manual editing of the GitHub Release is required.
 
-```bash
-git fetch origin --tags
-git log "$(git describe --tags --abbrev=0)..origin/main" --no-merges --oneline
-```
+### Merge
 
-Cut the branch and run the bump script. The release notes you pass become both the WordPress.org changelog entry and (later) the GitHub Release body, so write them for **merchants**, not engineers. Mention any developer-visible changes (renamed hooks, new settings, etc.) explicitly. Otherwise a generic maintenance line is fine.
-
-```bash
-git checkout main && git pull --ff-only origin main
-VERSION=1.2.3
-git checkout -b "release/v$VERSION"
-
-NOTES=$(cat <<'EOF'
-Routine maintenance update. No action required for merchants.
-
-Heads-up for developers: <only fill in if there is a real heads-up>.
-EOF
-)
-B64=$(printf '%s' "$NOTES" | base64 | tr -d '\n')
-node scripts/bump-wp-version.mjs "$VERSION" "$B64"
-```
-
-The script updates:
-
-- `sokin-pay.php` plugin header `Version` and the `PLATASOKIN_VERSION` constant.
-- `readme.txt` `Version`, `Stable tag`, and prepends a new entry under `== Changelog ==`.
-
-Review, commit, push, open the PR. The commit subject must be exactly `chore(release): v$VERSION` — `release.yml` keys off this prefix.
-
-```bash
-git diff
-git add sokin-pay.php readme.txt
-git commit -m "chore(release): v$VERSION"
-git push -u origin "release/v$VERSION"
-
-gh pr create \
-  --base main \
-  --head "release/v$VERSION" \
-  --title "release: v$VERSION" \
-  --label release \
-  --body "Prepares the release bump to v$VERSION.
-
-After merging, the Release workflow will tag and publish."
-```
-
-## 2. Merge → tag → GitHub Release
-
-Get the PR reviewed, then **squash and merge**. The squash subject must start with `chore(release): v`. Either of these work:
-
-- `chore(release): v1.2.3`
-- `chore(release): v1.2.3 (#42)` ← GitHub's default when squashing a labelled PR is fine; the trailing PR ref is allowed.
-
-Optionally add a bullet-list of merged commits in the squash body, matching the style established by past releases:
-
-```
-* fix(area): brief description
-* fix(area): brief description
-* docs: ...
-```
-
-This is purely cosmetic for `git log`; the GitHub Release notes are generated separately.
+Squash-merge the PR. The squash subject must start with `chore(release): v` — `release.yml` keys off this prefix. GitHub's default `chore(release): v$VERSION (#NN)` is fine; the trailing PR ref is allowed.
 
 After merge, watch the `Release` workflow:
 
@@ -98,36 +39,15 @@ After merge, watch the `Release` workflow:
 gh run watch -R platacapital/sokin-woocommerce-plugin
 ```
 
-It runs `semantic-release`, which creates the `v$VERSION` tag and the GitHub Release. The release body is sourced from the `= $VERSION =` block in `readme.txt` (via `scripts/extract-readme-notes.mjs`, wired up through `@semantic-release/exec` in `.releaserc.json`), so the merchant-facing notes you wrote in step 1 are used automatically. No manual editing.
+It runs `semantic-release`, which creates the `v$VERSION` tag and the GitHub Release.
 
-If you spot a typo or want to amend the wording after the fact, edit both `readme.txt` (in a follow-up PR) and the GitHub Release body (`gh release edit`) so the WordPress.org changelog stays in sync the next time `deploy-wporg.yml` runs.
+### `publish`
 
-## 3. Publish to WordPress.org
+Releases created by `semantic-release` use the default `GITHUB_TOKEN`. GitHub deliberately suppresses downstream workflow runs for events created by that token, so `deploy-wporg.yml` and `deploy-release.yaml` do not auto-fire. `scripts/release.sh publish v$VERSION` triggers both manually using `gh workflow run`. They build the dist zip, attach it to the GitHub Release, push to `plugins.svn.wordpress.org`, and redeploy `demo.wordpress.sokin.com`.
 
-### Subsequent releases (after the slug is approved)
+## Initial WordPress.org submission
 
-Run the manual button, since the release event won't auto-fire:
-
-**Actions → Deploy to WordPress.org → Run workflow → tag: `v$VERSION`**
-
-Or:
-
-```bash
-gh workflow run deploy-wporg.yml -f tag="v$VERSION"
-```
-
-The workflow:
-
-1. Looks up the GitHub Release for that tag, reads its body.
-2. Checks out the tagged code.
-3. Re-runs `bump-wp-version.mjs` with the body so `readme.txt` matches the release notes.
-4. Builds the distributable zip using `.distignore` as the deny list.
-5. Attaches the zip to the GitHub Release (`gh release upload --clobber`).
-6. Pushes to `plugins.svn.wordpress.org` via `10up/action-wordpress-plugin-deploy`.
-
-### Initial submission (one time, for the WP.org review queue)
-
-WordPress.org's review queue requires a clean zip submitted manually before the SVN repo exists. Build the same zip locally:
+The first time you publish a plugin slug, WordPress.org's review queue requires a clean zip submitted manually before the SVN repo exists. Build the same zip the workflow would build:
 
 ```bash
 WORKTREE=/tmp/sokin-pay-build
@@ -141,38 +61,22 @@ cd - && git worktree remove "$WORKTREE"
 ls -lh "/tmp/sokin-pay-v$VERSION.zip"
 ```
 
-Submit the zip at https://wordpress.org/plugins/developers/add/. Once approved, the slug exists on `plugins.svn.wordpress.org` and the manual button above starts working.
+Submit the zip at https://wordpress.org/plugins/developers/add/. Once approved, the slug exists on `plugins.svn.wordpress.org` and `scripts/release.sh publish` works end-to-end.
 
-## 4. Redeploy the demo
+## Failure modes
 
-Same model — manual button:
+**`Release` workflow didn't run after I merged the PR.** The squash commit subject didn't start with `chore(release): v`. Check `git log -1 main --format=%s`. Fix-forward by pushing a no-op commit with the correct subject.
 
-**Actions → Deploy Release Demo → Run workflow → tag: `v$VERSION`**
+**`Deploy to WordPress.org` fails with `svn: E170000: URL '…' doesn't exist`.** The plugin slug isn't yet approved on WordPress.org. Use the initial-submission flow above.
 
-Or:
+**`10up/action-wordpress-plugin-deploy@…` fails to resolve.** The action does not publish a floating major tag. It is pinned by SHA in `deploy-wporg.yml`; if you bump it, resolve the new SHA via `gh api repos/10up/action-wordpress-plugin-deploy/git/refs/tags/<tag>` and pin with the version in a trailing comment.
 
-```bash
-gh workflow run deploy-release.yaml -f tag="v$VERSION"
-```
+**`Deploy Release Demo` hangs at `Deploy via SSH`.** The EC2 host is unhealthy — out of memory, docker daemon stuck, or a previous compose run holding a lock. SSH in, inspect (`docker ps`, `docker info`, `free -m`, `df -h`), recover, and re-trigger.
 
-Optional inputs (`wordpress_version`, `php_version`, `wp_cli_version`, `woocommerce_version`) default to the values pinned in the workflow `env`. Override per run if you need to validate against a specific stack.
-
-The workflow builds an image from `tests/Dockerfile`, pushes to ECR, and SSHes into the demo host to redeploy via `docker-compose`. End state: https://demo.wordpress.sokin.com runs `v$VERSION`.
-
-## Troubleshooting
-
-**`Release` workflow didn't run after I merged the PR.** The squash commit subject didn't start with `chore(release): v`. Check `git log -1 main --format=%s`. Fix-forward by pushing a no-op commit with the correct subject, or by editing the merge commit (only if not yet pushed downstream).
-
-**`Deploy to WordPress.org` fails with `svn: E170000: URL '…' doesn't exist`.** The plugin slug isn't yet approved on WordPress.org. Use the initial-submission flow in step 3 to push to the review queue.
-
-**`10up/action-wordpress-plugin-deploy@…` fails to resolve.** The action does not publish a floating major tag (`@v2`). It is pinned by SHA in `deploy-wporg.yml`; if you bump it, resolve the new SHA via `gh api repos/10up/action-wordpress-plugin-deploy/git/refs/tags/<tag>` and pin with the version in a trailing comment.
-
-**Demo deploy or WP.org deploy did not auto-fire after a release.** Expected — see the note about `GITHUB_TOKEN` at the top. Run the manual button.
-
-**Plugin Check / WP.org review flags dev files in the zip** (`pnpm-lock.yaml`, `CONTRIBUTING.md`, etc.). Tighten `.distignore`. Rebuild the local zip per step 3 to verify before resubmitting.
+**Plugin Check / WP.org review flags dev files in the zip** (`pnpm-lock.yaml`, `CONTRIBUTING.md`, etc.). Tighten `.distignore` and rebuild the local zip before resubmitting.
 
 ## Future automation
 
-When the org issues a GitHub App token (or PAT) for releases, set it as `GITHUB_TOKEN` for the `npx semantic-release` step in `release.yml`. Releases created by an App or PAT **do** fire downstream `release` events, which makes stages 3 and 4 fully automatic. The manual buttons stay as a recovery path.
+When the org issues a GitHub App token (or PAT) for releases, set it as `GITHUB_TOKEN` for the `npx semantic-release` step in `release.yml`. Releases created by an App or PAT do fire downstream `release` events, which makes the `publish` step automatic. The script stays as a recovery path.
 
-A second improvement is extending `prepare-release-pr.yml` (currently blocked by SRE) to populate the squash commit body with a bullet list derived from `git log "$LAST_TAG..HEAD" --no-merges --pretty='* %s'`, matching the body style we use today by hand. Once SRE allows actions to open PRs, this automates step 1 entirely.
+A second improvement is unblocking `prepare-release-pr.yml` (currently blocked by SRE) so the release PR can be opened from the Actions UI instead of locally. The script and the workflow can coexist.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,178 @@
+# Releasing Sokin Pay
+
+This guide describes how to cut a new release of the plugin, publish it to WordPress.org, and redeploy the demo. The process is currently manual end-to-end because the GitHub-Actions automation that opens the release PR is blocked by SRE policy and `semantic-release`'s downstream-trigger limitation. The runbook below is what the automation would have done.
+
+## Overview
+
+| Stage | Trigger | Workflow |
+|---|---|---|
+| 1. Open release PR | Manual (this guide) | _would be_ `prepare-release-pr.yml` |
+| 2. Tag and create GitHub Release | Squash-merge of release PR with `chore(release): v…` subject | `release.yml` (runs `semantic-release`) |
+| 3. Publish to WordPress.org | GitHub Release published, **or** manual button | `deploy-wporg.yml` |
+| 4. Redeploy demo site | GitHub Release published, **or** manual button | `deploy-release.yaml` |
+
+**Important.** Releases created by `semantic-release` use the default `GITHUB_TOKEN`. GitHub deliberately suppresses downstream workflow runs for events created by that token, so stages 3 and 4 do **not** auto-fire from stage 2. Use the manual buttons until the org issues a GitHub App token (or PAT) for the release workflow.
+
+## Prerequisites
+
+- Push access to `main` and the ability to merge release PRs.
+- `gh` CLI authenticated against `platacapital/sokin-woocommerce-plugin`.
+- Node.js 22.14.0 (matches the workflow). Only needed for running the bump script.
+
+## 1. Cut the release PR
+
+Pick the next version using [Conventional Commits](https://www.conventionalcommits.org/) rules from `.releaserc.json`:
+
+- `fix:` / `perf:` → patch
+- `feat:` → minor
+- Any commit with `BREAKING CHANGE:` footer or `!` in the type → major
+- `chore:`, `docs:`, `ci:`, `build:`, `refactor:`, `test:`, `style:` → no release on their own
+
+Sanity-check the commits since the last tag:
+
+```bash
+git fetch origin --tags
+git log "$(git describe --tags --abbrev=0)..origin/main" --no-merges --oneline
+```
+
+Cut the branch and run the bump script. The release notes you pass become both the WordPress.org changelog entry and (later) the GitHub Release body, so write them for **merchants**, not engineers. Mention any developer-visible changes (renamed hooks, new settings, etc.) explicitly. Otherwise a generic maintenance line is fine.
+
+```bash
+git checkout main && git pull --ff-only origin main
+VERSION=1.2.3
+git checkout -b "release/v$VERSION"
+
+NOTES=$(cat <<'EOF'
+Routine maintenance update. No action required for merchants.
+
+Heads-up for developers: <only fill in if there is a real heads-up>.
+EOF
+)
+B64=$(printf '%s' "$NOTES" | base64 | tr -d '\n')
+node scripts/bump-wp-version.mjs "$VERSION" "$B64"
+```
+
+The script updates:
+
+- `sokin-pay.php` plugin header `Version` and the `PLATASOKIN_VERSION` constant.
+- `readme.txt` `Version`, `Stable tag`, and prepends a new entry under `== Changelog ==`.
+
+Review, commit, push, open the PR. The commit subject must be exactly `chore(release): v$VERSION` — `release.yml` keys off this prefix.
+
+```bash
+git diff
+git add sokin-pay.php readme.txt
+git commit -m "chore(release): v$VERSION"
+git push -u origin "release/v$VERSION"
+
+gh pr create \
+  --base main \
+  --head "release/v$VERSION" \
+  --title "release: v$VERSION" \
+  --label release \
+  --body "Prepares the release bump to v$VERSION.
+
+After merging, the Release workflow will tag and publish."
+```
+
+## 2. Merge → tag → GitHub Release
+
+Get the PR reviewed, then **squash and merge**. The squash subject must start with `chore(release): v`. Either of these work:
+
+- `chore(release): v1.2.3`
+- `chore(release): v1.2.3 (#42)` ← GitHub's default when squashing a labelled PR is fine; the trailing PR ref is allowed.
+
+Optionally add a bullet-list of merged commits in the squash body, matching the style established by past releases:
+
+```
+* fix(area): brief description
+* fix(area): brief description
+* docs: ...
+```
+
+This is purely cosmetic for `git log`; the GitHub Release notes are generated separately.
+
+After merge, watch the `Release` workflow:
+
+```bash
+gh run watch -R platacapital/sokin-woocommerce-plugin
+```
+
+It runs `semantic-release`, which creates the `v$VERSION` tag and the GitHub Release. The release body is sourced from the `= $VERSION =` block in `readme.txt` (via `scripts/extract-readme-notes.mjs`, wired up through `@semantic-release/exec` in `.releaserc.json`), so the merchant-facing notes you wrote in step 1 are used automatically. No manual editing.
+
+If you spot a typo or want to amend the wording after the fact, edit both `readme.txt` (in a follow-up PR) and the GitHub Release body (`gh release edit`) so the WordPress.org changelog stays in sync the next time `deploy-wporg.yml` runs.
+
+## 3. Publish to WordPress.org
+
+### Subsequent releases (after the slug is approved)
+
+Run the manual button, since the release event won't auto-fire:
+
+**Actions → Deploy to WordPress.org → Run workflow → tag: `v$VERSION`**
+
+Or:
+
+```bash
+gh workflow run deploy-wporg.yml -f tag="v$VERSION"
+```
+
+The workflow:
+
+1. Looks up the GitHub Release for that tag, reads its body.
+2. Checks out the tagged code.
+3. Re-runs `bump-wp-version.mjs` with the body so `readme.txt` matches the release notes.
+4. Builds the distributable zip using `.distignore` as the deny list.
+5. Attaches the zip to the GitHub Release (`gh release upload --clobber`).
+6. Pushes to `plugins.svn.wordpress.org` via `10up/action-wordpress-plugin-deploy`.
+
+### Initial submission (one time, for the WP.org review queue)
+
+WordPress.org's review queue requires a clean zip submitted manually before the SVN repo exists. Build the same zip locally:
+
+```bash
+WORKTREE=/tmp/sokin-pay-build
+rm -rf "$WORKTREE"
+git worktree add --detach "$WORKTREE" "v$VERSION"
+cd "$WORKTREE"
+rsync -rc --delete --exclude-from=.distignore ./ ./dist/
+cd dist
+zip -r "/tmp/sokin-pay-v$VERSION.zip" . -x '*.DS_Store'
+cd - && git worktree remove "$WORKTREE"
+ls -lh "/tmp/sokin-pay-v$VERSION.zip"
+```
+
+Submit the zip at https://wordpress.org/plugins/developers/add/. Once approved, the slug exists on `plugins.svn.wordpress.org` and the manual button above starts working.
+
+## 4. Redeploy the demo
+
+Same model — manual button:
+
+**Actions → Deploy Release Demo → Run workflow → tag: `v$VERSION`**
+
+Or:
+
+```bash
+gh workflow run deploy-release.yaml -f tag="v$VERSION"
+```
+
+Optional inputs (`wordpress_version`, `php_version`, `wp_cli_version`, `woocommerce_version`) default to the values pinned in the workflow `env`. Override per run if you need to validate against a specific stack.
+
+The workflow builds an image from `tests/Dockerfile`, pushes to ECR, and SSHes into the demo host to redeploy via `docker-compose`. End state: https://demo.wordpress.sokin.com runs `v$VERSION`.
+
+## Troubleshooting
+
+**`Release` workflow didn't run after I merged the PR.** The squash commit subject didn't start with `chore(release): v`. Check `git log -1 main --format=%s`. Fix-forward by pushing a no-op commit with the correct subject, or by editing the merge commit (only if not yet pushed downstream).
+
+**`Deploy to WordPress.org` fails with `svn: E170000: URL '…' doesn't exist`.** The plugin slug isn't yet approved on WordPress.org. Use the initial-submission flow in step 3 to push to the review queue.
+
+**`10up/action-wordpress-plugin-deploy@…` fails to resolve.** The action does not publish a floating major tag (`@v2`). It is pinned by SHA in `deploy-wporg.yml`; if you bump it, resolve the new SHA via `gh api repos/10up/action-wordpress-plugin-deploy/git/refs/tags/<tag>` and pin with the version in a trailing comment.
+
+**Demo deploy or WP.org deploy did not auto-fire after a release.** Expected — see the note about `GITHUB_TOKEN` at the top. Run the manual button.
+
+**Plugin Check / WP.org review flags dev files in the zip** (`pnpm-lock.yaml`, `CONTRIBUTING.md`, etc.). Tighten `.distignore`. Rebuild the local zip per step 3 to verify before resubmitting.
+
+## Future automation
+
+When the org issues a GitHub App token (or PAT) for releases, set it as `GITHUB_TOKEN` for the `npx semantic-release` step in `release.yml`. Releases created by an App or PAT **do** fire downstream `release` events, which makes stages 3 and 4 fully automatic. The manual buttons stay as a recovery path.
+
+A second improvement is extending `prepare-release-pr.yml` (currently blocked by SRE) to populate the squash commit body with a bullet list derived from `git log "$LAST_TAG..HEAD" --no-merges --pretty='* %s'`, matching the body style we use today by hand. Once SRE allows actions to open PRs, this automates step 1 entirely.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@semantic-release/exec": "7.1.0",
         "@semantic-release/git": "10.0.1",
         "@semantic-release/github": "12.0.6",
-        "@semantic-release/release-notes-generator": "14.1.0",
         "conventional-changelog-conventionalcommits": "9.3.1",
         "semantic-release": "25.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "@semantic-release/exec": "7.1.0",
     "@semantic-release/git": "10.0.1",
     "@semantic-release/github": "12.0.6",
-    "@semantic-release/release-notes-generator": "14.1.0",
     "semantic-release": "25.0.3"
   },
   "overrides": {

--- a/scripts/extract-readme-notes.mjs
+++ b/scripts/extract-readme-notes.mjs
@@ -2,7 +2,9 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// Prints the WordPress.org changelog body for a given version on stdout.
+// Prints the merchant-facing release notes for a given version on stdout,
+// extracted from the matching changelog entry in readme.txt with the
+// `* Released: <date>` metadata line stripped.
 // Used as semantic-release's `generateNotesCmd` (via @semantic-release/exec) so
 // the GitHub Release body matches the merchant-facing notes already curated in
 // readme.txt during the release-PR step. Single source of truth, no manual edit.

--- a/scripts/extract-readme-notes.mjs
+++ b/scripts/extract-readme-notes.mjs
@@ -1,0 +1,55 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Prints the WordPress.org changelog body for a given version on stdout.
+// Used as semantic-release's `generateNotesCmd` (via @semantic-release/exec) so
+// the GitHub Release body matches the merchant-facing notes already curated in
+// readme.txt during the release-PR step. Single source of truth, no manual edit.
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+
+const version = process.argv[2];
+if (!version) {
+  console.error('Missing required version argument.');
+  process.exit(1);
+}
+
+const readmePath = path.join(projectRoot, 'readme.txt');
+const contents = await readFile(readmePath, 'utf8');
+const lines = contents.split(/\r?\n/);
+
+const headingPattern = new RegExp(`^=+\\s*${escapeRegex(version)}\\s*=+\\s*$`);
+const nextEntryPattern = /^=+\s*[^=\n]+?\s*=+\s*$/;
+
+const startIdx = lines.findIndex((line) => headingPattern.test(line));
+if (startIdx === -1) {
+  console.error(`No changelog entry for version ${version} in readme.txt.`);
+  process.exit(2);
+}
+
+const bodyLines = [];
+for (let i = startIdx + 1; i < lines.length; i += 1) {
+  if (nextEntryPattern.test(lines[i])) {
+    break;
+  }
+  bodyLines.push(lines[i]);
+}
+
+const filtered = bodyLines
+  .filter((line) => !/^\s*\*\s*Released:/i.test(line))
+  .join('\n')
+  .trim();
+
+if (!filtered) {
+  console.error(`Changelog entry for version ${version} is empty after filtering.`);
+  process.exit(3);
+}
+
+process.stdout.write(`${filtered}\n`);
+
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# Sokin Pay release helper.
+#
+# Walks an engineer through the manual release flow documented in RELEASING.md.
+# Subcommands:
+#   prepare              Open a release PR for the next version (default).
+#   publish vX.Y.Z       Fire the post-merge deploy workflows for an existing tag.
+set -euo pipefail
+
+REPO_SLUG="platacapital/sokin-woocommerce-plugin"
+RELEASE_COMMIT_PREFIX="chore(release): v"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/release.sh [prepare | publish vX.Y.Z]
+
+  prepare              Open a release PR for the next version. Prompts for the
+                       bump type and merchant-facing notes, runs the version
+                       bump, and opens the PR.
+  publish vX.Y.Z       Trigger Deploy to WordPress.org and Deploy Release Demo
+                       for an existing GitHub Release.
+
+With no arguments, runs `prepare`.
+EOF
+}
+
+# ----- shared helpers -------------------------------------------------------
+
+require() {
+  local bin="$1"
+  command -v "$bin" >/dev/null 2>&1 || {
+    echo "error: required command '$bin' not found on PATH" >&2
+    exit 1
+  }
+}
+
+confirm() {
+  local prompt="$1"
+  local reply
+  printf '%s [y/N] ' "$prompt"
+  read -r reply
+  [[ "$reply" =~ ^[Yy]$ ]]
+}
+
+repo_root() {
+  git rev-parse --show-toplevel
+}
+
+# ----- prepare --------------------------------------------------------------
+
+prepare_release() {
+  require git
+  require gh
+  require node
+
+  cd "$(repo_root)"
+
+  if [[ -n "$(git status --porcelain)" ]]; then
+    echo "error: working tree has uncommitted changes; commit or stash first" >&2
+    exit 1
+  fi
+
+  echo "==> Syncing main"
+  git fetch --tags --quiet origin
+  git checkout main --quiet
+  git pull --ff-only --quiet origin main
+
+  local last_tag
+  last_tag="$(git describe --tags --abbrev=0)"
+  local current_version="${last_tag#v}"
+
+  echo
+  echo "Last released version: $current_version"
+  echo "Commits since $last_tag (these will be in the release):"
+  echo
+  git log "$last_tag..HEAD" --no-merges --pretty='  - %s' || true
+  echo
+
+  local bump
+  bump="$(prompt_bump)"
+
+  local next_version
+  next_version="$(compute_next_version "$current_version" "$bump")"
+  echo
+  echo "Next version: $next_version  ($bump bump from $current_version)"
+  echo
+
+  if ! confirm "Continue with v$next_version?"; then
+    echo "Aborted." >&2
+    exit 1
+  fi
+
+  local notes
+  notes="$(collect_notes "$next_version")"
+
+  echo
+  echo "==> Cutting branch release/v$next_version"
+  git checkout -b "release/v$next_version" --quiet
+
+  echo "==> Running bump script"
+  local b64
+  b64="$(printf '%s' "$notes" | base64 | tr -d '\n')"
+  node scripts/bump-wp-version.mjs "$next_version" "$b64"
+
+  echo
+  echo "==> Diff to be committed:"
+  echo
+  git --no-pager diff -- sokin-pay.php readme.txt
+  echo
+
+  if ! confirm "Commit and push this diff?"; then
+    echo "Leaving branch in place for inspection. To abort: git checkout main && git branch -D release/v$next_version" >&2
+    exit 1
+  fi
+
+  echo "==> Committing and pushing"
+  git add sokin-pay.php readme.txt
+  git commit --quiet -m "${RELEASE_COMMIT_PREFIX}${next_version}"
+  git push --quiet -u origin "release/v$next_version"
+
+  echo "==> Opening PR"
+  local pr_url
+  pr_url="$(
+    gh pr create \
+      --base main \
+      --head "release/v$next_version" \
+      --title "release: v$next_version" \
+      --label release \
+      --body "Prepares the release bump to v$next_version.
+
+After merging, the Release workflow will tag and publish."
+  )"
+
+  print_prepare_next_steps "$next_version" "$pr_url"
+}
+
+prompt_bump() {
+  echo "Pick a bump type." >&2
+  echo "  1) patch  (default; for fix/perf only)" >&2
+  echo "  2) minor  (new features)" >&2
+  echo "  3) major  (breaking changes)" >&2
+  printf 'Choice [1]: ' >&2
+  local choice
+  read -r choice
+  case "${choice:-1}" in
+    1|patch) echo patch ;;
+    2|minor) echo minor ;;
+    3|major) echo major ;;
+    *) echo "error: invalid choice '$choice'" >&2; exit 1 ;;
+  esac
+}
+
+compute_next_version() {
+  local current="$1" bump="$2"
+  local IFS='.'
+  read -r major minor patch <<<"$current"
+  : "${major:=0}" "${minor:=0}" "${patch:=0}"
+  case "$bump" in
+    major) major=$((major + 1)); minor=0; patch=0 ;;
+    minor) minor=$((minor + 1)); patch=0 ;;
+    patch) patch=$((patch + 1)) ;;
+  esac
+  echo "$major.$minor.$patch"
+}
+
+collect_notes() {
+  local version="$1"
+  local tmp
+  tmp="$(mktemp -t "release-notes-v${version}.XXXXXX")"
+  cat >"$tmp" <<EOF
+# Release notes for v$version
+#
+# These notes go into:
+#   - the WordPress.org changelog (readme.txt) - merchants will read this,
+#   - the GitHub Release body, automatically.
+#
+# Write for store operators, not engineers. Mention any developer-visible
+# changes (renamed hooks, new settings) explicitly. Otherwise a generic
+# maintenance line is fine.
+#
+# Lines starting with '#' are ignored. Save and exit when done.
+
+Routine maintenance update. No action required for merchants.
+EOF
+  "${EDITOR:-vi}" "$tmp"
+
+  local cleaned
+  cleaned="$(grep -v '^#' "$tmp" | sed -e '/./,$!d' | awk 'NR>0 {print} END{}')"
+  rm -f "$tmp"
+
+  if [[ -z "$(printf '%s' "$cleaned" | tr -d '[:space:]')" ]]; then
+    echo "error: release notes are empty; aborting" >&2
+    exit 1
+  fi
+  printf '%s\n' "$cleaned"
+}
+
+print_prepare_next_steps() {
+  local version="$1" pr_url="$2"
+  cat <<EOF
+
+==============================================================================
+Release PR opened: $pr_url
+
+Next steps:
+
+  1. Get the PR reviewed.
+  2. Squash and merge. The squash subject MUST start with
+        ${RELEASE_COMMIT_PREFIX}${version}
+     GitHub's default '${RELEASE_COMMIT_PREFIX}${version} (#NN)' is fine.
+  3. The Release workflow will then tag and publish v$version. Watch with:
+        gh run watch -R $REPO_SLUG
+  4. Once the GitHub Release exists, fire the deploys:
+        scripts/release.sh publish v$version
+==============================================================================
+EOF
+}
+
+# ----- publish --------------------------------------------------------------
+
+publish_release() {
+  require gh
+  cd "$(repo_root)"
+
+  local tag="${1:-}"
+  if [[ -z "$tag" ]]; then
+    echo "error: publish requires a tag argument, e.g. v1.2.3" >&2
+    exit 64
+  fi
+  if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: tag '$tag' must look like vX.Y.Z" >&2
+    exit 64
+  fi
+
+  if ! gh release view "$tag" --repo "$REPO_SLUG" >/dev/null 2>&1; then
+    echo "error: GitHub Release $tag not found in $REPO_SLUG" >&2
+    exit 1
+  fi
+
+  echo "==> Triggering Deploy to WordPress.org for $tag"
+  gh workflow run deploy-wporg.yml --repo "$REPO_SLUG" -f "tag=$tag"
+
+  echo "==> Triggering Deploy Release Demo for $tag"
+  gh workflow run deploy-release.yaml --repo "$REPO_SLUG" -f "tag=$tag"
+
+  cat <<EOF
+
+Both deploys submitted. Watch progress with:
+  gh run watch -R $REPO_SLUG
+
+If 'Deploy to WordPress.org' fails because the SVN URL doesn't exist, the
+plugin slug isn't yet approved on WordPress.org. See RELEASING.md for the
+initial-submission flow.
+EOF
+}
+
+# ----- dispatch -------------------------------------------------------------
+
+main() {
+  local cmd="${1:-prepare}"
+  case "$cmd" in
+    prepare) shift || true; prepare_release "$@" ;;
+    publish) shift || true; publish_release "$@" ;;
+    -h|--help|help) usage; exit 0 ;;
+    *) usage; exit 64 ;;
+  esac
+}
+
+main "$@"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -114,8 +114,14 @@ prepare_release() {
   fi
 
   echo "==> Committing and pushing"
+  local commit_body
+  commit_body="$(git log "$last_tag..HEAD" --no-merges --pretty='* %s')"
   git add sokin-pay.php readme.txt
-  git commit --quiet -m "${RELEASE_COMMIT_PREFIX}${next_version}"
+  if [[ -n "$commit_body" ]]; then
+    git commit --quiet -m "${RELEASE_COMMIT_PREFIX}${next_version}" -m "$commit_body"
+  else
+    git commit --quiet -m "${RELEASE_COMMIT_PREFIX}${next_version}"
+  fi
   git push --quiet -u origin "release/v$next_version"
 
   echo "==> Opening PR"


### PR DESCRIPTION
## Summary

Two related changes that together make the manual release flow forgettable in a good way.

### 1. GitHub Release notes sourced from \`readme.txt\`

Yesterday's v1.1.4 release exposed a problem: \`semantic-release\`'s default \`@semantic-release/release-notes-generator\` produced a dev-facing changelog (a list of conventional-commit subjects with author/PR refs) that we then had to edit by hand on the GitHub Release, and which would otherwise have flowed into the WordPress.org changelog via \`deploy-wporg.yml\`.

- \`scripts/extract-readme-notes.mjs\` reads \`readme.txt\` and prints the body of the \`= <version> =\` block on stdout, dropping the metadata \`* Released:\` line.
- \`.releaserc.json\` swaps \`@semantic-release/release-notes-generator\` for an \`@semantic-release/exec\` step that runs the script with \`\${nextRelease.version}\`. \`@semantic-release/exec\` was already a dev-dependency.
- \`@semantic-release/github\` then publishes the GitHub Release with those notes verbatim.

Net: curate merchant-facing notes once, in the release PR; they appear unchanged on the GitHub Release and round-trip into the WordPress.org changelog. No more manual \`gh release edit\`.

Removes the now-unused \`@semantic-release/release-notes-generator\` from \`devDependencies\` (still installed transitively by \`semantic-release\`, but no longer wired up).

### 2. \`scripts/release.sh\` — single entry point for the manual flow

Replaces the long-form runbook in \`RELEASING.md\` with a script that walks an engineer through the steps:

- \`scripts/release.sh prepare\` — verifies the working tree, syncs main, shows commits since the last tag, prompts for bump type, opens \`\$EDITOR\` for merchant-facing notes, runs the bump, shows the diff for confirmation, commits with the gating \`chore(release): v…\` subject, pushes, and opens the PR.
- \`scripts/release.sh publish vX.Y.Z\` — verifies the GitHub Release exists for the tag and fires both \`Deploy to WordPress.org\` and \`Deploy Release Demo\` via \`gh workflow run\`.

\`RELEASING.md\` shrinks from 179 lines of prose to 82 lines of prerequisites + failure-mode reference (now also covering the EC2-OOM case we hit this morning).

## Test plan

- [x] \`npx semantic-release --dry-run\` loads the new config and registers \`@semantic-release/exec\` as the \`generateNotes\` plugin.
- [x] \`node scripts/extract-readme-notes.mjs 1.1.4\` returns the v1.1.4 merchant-facing bullets only; \`1.1.3\` returns the v1.1.3 bullets; missing version exits non-zero with a clear stderr message.
- [x] \`scripts/release.sh --help\` prints usage; missing/invalid \`publish\` arguments exit \`64\` with helpful errors; unrecognised subcommand prints usage.
- [x] Internal version-bump arithmetic verified for patch/minor/major (1.1.4 → 1.1.5 / 1.2.0 / 2.0.0; 9.9.9 major → 10.0.0).
- [ ] Next real release: dry-run the full \`prepare\` path on a throwaway branch, confirm the GitHub Release body matches the \`readme.txt\` block, and that \`publish\` fires both deploys for the resulting tag.