### PR TITLE
fix(wporg): address pre-review feedback on enqueue and readme

### DIFF
--- a/includes/class-platasokin-wc-gateway.php
+++ b/includes/class-platasokin-wc-gateway.php
@@ -799,17 +799,3 @@ function platasokin_init_gateway_class() {
 	}
 }
 
-add_filter( 'woocommerce_order_actions', 'platasokin_hide_refund_button_for_failed_orders', 10, 2 );
-
-/**
- * @param array<string, string> $actions Order actions.
- * @param WC_Order              $order   Order.
- * @return array<string, string>
- */
-function platasokin_hide_refund_button_for_failed_orders( $actions, $order ) {
-	if ( 'failed' === $order->get_status() ) {
-		$css = '<style>.button.refund-items{display: none;}</style>';
-		echo wp_kses( $css, array( 'style' => array() ) );
-	}
-	return $actions;
-}

--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 Easily accept payments on your WordPress site via Sokin Pay payment gateway.
 
-=== Description ===
+== Description ==
 This plugin seamlessly integrates with your WooCommerce store, providing a secure and efficient way to process payments. Enable a variety of secure payment options, including credit cards and pay by bank.
 Register your business account at [sokin.com](https://sokin.com/business/business-account-signup/).
 
@@ -65,11 +65,6 @@ For any issues or questions, please contact our support team at [support@sokin.c
 == Installation ==
 * It is required to install WooCommerce plugin (https://wordpress.org/plugins/woocommerce) before Sokin Pay installation.
 * Upload the Sokin Pay plugin to your WordPress website, activate it, and then configure the API settings.
-
-== Features ==
-* Quick installation and setup.
-
-The setup is very easy. Once you have installed the plugin, all you need to do is enter your Sokin API credentials in the plugin settings and your website will be ready to accept payments.
 
 == Frequently Asked Questions ==
 Is WooCommerce plugin mandatory for Sokin Pay plugin?

--- a/sokin-pay.php
+++ b/sokin-pay.php
@@ -71,6 +71,21 @@ function platasokin_register_gateway_scripts( $hook ) {
 		true
 	);
 	wp_enqueue_script( 'platasokin_gateway_admin' );
+
+	// Register an inline-only style handle so per-order rules (e.g. hiding the
+	// refund button on failed orders) can be attached via wp_add_inline_style
+	// instead of echoing <style> tags from filters.
+	wp_register_style( 'platasokin_gateway_admin', false, array(), PLATASOKIN_VERSION );
+	wp_enqueue_style( 'platasokin_gateway_admin' );
+
+	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only screen parameter, no state change.
+	$order_id = isset( $_GET['post'] ) ? absint( wp_unslash( $_GET['post'] ) ) : 0;
+	if ( $order_id && function_exists( 'wc_get_order' ) ) {
+		$order = wc_get_order( $order_id );
+		if ( $order && 'failed' === $order->get_status() ) {
+			wp_add_inline_style( 'platasokin_gateway_admin', '.button.refund-items{display:none;}' );
+		}
+	}
 }
 
 add_action( 'admin_enqueue_scripts', 'platasokin_register_gateway_scripts' );

--- a/sokin-pay.php
+++ b/sokin-pay.php
@@ -75,15 +75,15 @@ function platasokin_register_gateway_scripts( $hook ) {
 	// Register an inline-only style handle so per-order rules (e.g. hiding the
 	// refund button on failed orders) can be attached via wp_add_inline_style
 	// instead of echoing <style> tags from filters.
-	wp_register_style( 'platasokin_gateway_admin', false, array(), PLATASOKIN_VERSION );
-	wp_enqueue_style( 'platasokin_gateway_admin' );
+	wp_register_style( 'platasokin_gateway_admin_style', false, array(), PLATASOKIN_VERSION );
+	wp_enqueue_style( 'platasokin_gateway_admin_style' );
 
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- read-only screen parameter, no state change.
 	$order_id = isset( $_GET['post'] ) ? absint( wp_unslash( $_GET['post'] ) ) : 0;
 	if ( $order_id && function_exists( 'wc_get_order' ) ) {
 		$order = wc_get_order( $order_id );
 		if ( $order && 'failed' === $order->get_status() ) {
-			wp_add_inline_style( 'platasokin_gateway_admin', '.button.refund-items{display:none;}' );
+			wp_add_inline_style( 'platasokin_gateway_admin_style', '.button.refund-items{display:none;}' );
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Addresses the two items the WordPress.org plugin review team flagged on our initial v1.1.4 submission ([review ID AUTOPREREVIEW … 8May26/4.0](https://wordpress.org/plugins/developers/add/)):

### 1. Inline \`<style>\` echoed from a filter (\`includes/class-platasokin-wc-gateway.php:610\`)

Reviewer asked us to use the WP enqueue API instead of echoing a \`<style>\` tag from \`woocommerce_order_actions\`.

The CSS only needs to apply to the WooCommerce order edit screen, and only when the order's status is \`failed\` (so the refund button is hidden). The fix:

- In the existing \`admin_enqueue_scripts\` callback (\`platasokin_register_gateway_scripts\`), which already gates on \`post.php\`/\`post-new.php\` + \`shop_order\`, register an inline-only style handle (\`wp_register_style( 'platasokin_gateway_admin', false, … )\`).
- Look up the current order via \`wc_get_order( absint( \$_GET['post'] ) )\` and, if \`failed\`, attach the rule with \`wp_add_inline_style\`.
- Delete the \`woocommerce_order_actions\` filter and the function that echoed the \`<style>\` tag.

Side benefits: no more side-effecting filter, no \`wp_kses\` of a \`<style>\` tag, the rule is properly versioned with \`PLATASOKIN_VERSION\`.

### 2. Malformed \`readme.txt\` section

Reviewer flagged the \`== Features ==\` section as malformed (a single bullet followed by a paragraph). The same feature list is already present under the Description section (\`#### Features\`), so the standalone section is removed.

While in there, fixed the Description section heading from \`=== Description ===\` (three equals — WordPress.org parser treats that as a plugin title repeat) to \`== Description ==\` (two equals — the correct section-heading syntax).

## Test plan

- [x] \`php -l sokin-pay.php\` and \`php -l includes/class-platasokin-wc-gateway.php\` both syntax-clean.
- [ ] Visual verification on the demo: open a failed order's edit screen and confirm the refund button is hidden; open a non-failed order and confirm the refund button is visible. View source — there should be no inline \`<style>\` tag from this plugin.
- [ ] After merge, build the clean review zip (\`RELEASING.md\` → \"Initial WordPress.org submission\") and email it back to the WordPress.org plugin review team replying to their pre-review.